### PR TITLE
Added component-create to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "component-ls": "bin/component-ls",
     "component-convert": "bin/component-convert",
     "component-build": "bin/component-build",
-    "component-search": "bin/component-search"
+    "component-search": "bin/component-search",
+    "component-create": "bin/component-create"
   },
   "main": "index"
 }


### PR DESCRIPTION
`component create` isn't linked when you run `npm install -g component`. This is looking really great by the way!
