### PR TITLE
Use win-spawn

### DIFF
--- a/bin/component
+++ b/bin/component
@@ -6,7 +6,7 @@
 
 var program = require('commander')
   , utils = require('../lib/utils')
-  , spawn = require('child_process').spawn;
+  , spawn = require('win-spawn');
 
 // usage
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "component-builder": "0.0.5",
     "string-to-js": "0.0.1",
     "batch": "*",
-    "debug": "*"
+    "debug": "*",
+    "win-spawn": "*"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
An alternative fix for #32

Win-spawn makes spawn use cmd on windows, and work like normal on unix systems.

There is no real need to worry about the exit codes.  On windows the exit code will be 1 for virtually all errors, so we can glean no useful information about what went wrong from that.

In any case, if the command doesn't exist we get the fairly helpful message:

```
'component-foo' is not recognized as an internal or external command,
operable program or batch file.
```
