### PR TITLE
Use array notation for standalone name.

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -79,7 +79,7 @@ builder.build(function(err, obj){
   if (standalone) js.write(';(function(){\n');
   js.write(obj.require);
   js.write(obj.js);
-  if (standalone) js.write('window.' + name + ' = require("' + conf.name + '");\n');
+  if (standalone) js.write('window["' + name + '"] = require("' + conf.name + '");\n');
   if (standalone) js.write('})();');
 
   if (!program.verbose) return;


### PR DESCRIPTION
Prevents errors being generated for `standalone` components with a hyphen in the name. 

Currently "foo-bar" becomes:

``` javascript
window.foo-bar = require(...);
```

Needs to be:

``` javascript
window['foo-bar'] = require(...);
```
