### PR TITLE
make should run component install --dev if there's a component.json change

### DIFF
--- a/bin/component-create
+++ b/bin/component-create
@@ -138,7 +138,7 @@ function createMakefile(obj) {
   }
 
   // components target
-  buf += 'components:\n';
+  buf += 'components: component.json\n';
   buf += '\t@component install --dev\n\n';
 
   // clean phony


### PR DESCRIPTION
A change to component.json does not trigger installation of possibly new components, forcing you to manually `component install --dev` after changing dependencies in component.json.

This patch corrects this.
