### PR TITLE
Check package description exists when searching. 

### DIFF
--- a/bin/component-search
+++ b/bin/component-search
@@ -51,6 +51,7 @@ function truncate(str, repo) {
  */
 
 function description(str) {
+  if (!str) return '';
   var space;
   var width = cols - 20;
   for (var i = 0; i < str.length; ++i) {


### PR DESCRIPTION
Default package description to empty string.

Fixes #83.
