### PR TITLE
ability to run component from local install

### DIFF
--- a/bin/component
+++ b/bin/component
@@ -6,6 +6,7 @@
 
 var program = require('commander')
   , utils = require('../lib/utils')
+  , path = require('path')
   , spawn = require('win-spawn');
 
 // usage
@@ -60,7 +61,7 @@ if (!cmd) {
 
 // executable
 
-var bin = 'component-' + cmd;
+var bin = path.join(__dirname, 'component-' + cmd);
 
 // spawn
 


### PR DESCRIPTION
before if you ran `./node_modules/.bin/component build -h`
you would get `execvp(): No such file or directory`.
