### PR TITLE
'end' event never emitted for dependencies

### DIFF
--- a/lib/Package.js
+++ b/lib/Package.js
@@ -242,6 +242,7 @@ Package.prototype.getDependencies = function(deps, fn){
       });
       self.emit('dep', pkg);
       pkg.on('end', done);
+      pkg.on('exists', function() { done(); });
       pkg.install();
     });
   });


### PR DESCRIPTION
I found that when installing a package with dependencies that already existed, the 'end' event is never fired after pkg.install() - this is because the batch never finishes.

function is wrapped, because the argument passed on the exists event will be considered an error
