### PR TITLE
un-indent bullet points in readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,3 @@
-
   ![web component logo](http://i49.tinypic.com/e7nj9v.png)
 
   Component package manager for building a better web.
@@ -220,7 +219,7 @@ $ make test
 
   Open source application examples:
   
-    - [Todo list](https://github.com/component/todo)
+  - [Todo list](https://github.com/component/todo)
 
 ## License 
 


### PR DESCRIPTION
this stops them looking like code and makes markdown links render properly.
