### PR TITLE
Remove the mention of `COMPONENT_PATH`

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -37,10 +37,6 @@ program.on('--help', function(){
   console.log('    # build standalone as window.$');
   console.log('    $ component build --standalone $');
   console.log();
-  console.log('    # add lookup paths');
-  console.log('    $ COMPONENT_PATH=lib');
-  console.log('    $ component build');
-  console.log();
 });
 
 // parse argv

--- a/lib/component.js
+++ b/lib/component.js
@@ -62,7 +62,7 @@ exports.lookup = function(pkg, paths){
 exports.dependenciesOf = function(pkg, paths, parent){
   paths = paths || [];
   var path = exports.lookup(pkg, paths);
-  if (!path && parent) throw new Error('failed to lookup "' + parent + '"\'s dep "' + pkg + '" within COMPONENT_PATH');
+  if (!path && parent) throw new Error('failed to lookup "' + parent + '"\'s dep "' + pkg + '"');
   if (!path) throw new Error('failed to lookup "' + pkg + '"');
   var conf = require(resolve(path, 'component.json'));
   var deps = [conf.dependencies || {}];


### PR DESCRIPTION
To avoid confusion, remove the mention of `COMPONENT_PATH` from `component build --help` and error output.
