### PR TITLE
Support building separate files

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -17,6 +17,7 @@ var program = require('commander')
 
 program
   .option('-d, --dev', 'build development dependencies')
+  .option('-S, --separate', 'output separate files instead of a single concatenated file')
   .option('-s, --standalone <name>', 'build a stand-alone version of the component')
   .option('-o, --out <dir>', 'output directory defaulting to ./build', 'build')
   .option('-n, --name <file>', 'base name for build files defaulting to build', 'build')
@@ -55,11 +56,6 @@ var standalone = program.standalone;
 
 mkdir.sync(program.out);
 
-// output streams
-
-var js = fs.createWriteStream(path.join(program.out, program.name + '.js'));
-var css = fs.createWriteStream(path.join(program.out, program.name + '.css'));
-
 // build
 
 var builder = new Builder(process.cwd());
@@ -77,6 +73,10 @@ var start = new Date;
 
 if (program.dev) builder.development();
 
+// --separate
+
+if (program.separate) builder.separate();
+
 if (program.verbose) console.log();
 builder.build(function(err, obj){
   if (err) utils.fatal(err.message);
@@ -85,23 +85,47 @@ builder.build(function(err, obj){
     ? standalone
     : conf.name;
 
-  css.write(obj.css);
-  if (standalone) js.write(';(function(){\n');
-  js.write(obj.require);
-  js.write(obj.js);
-  if (standalone) js.write('  if ("undefined" == typeof module) {\n');
-  if (standalone) js.write('    window.' + name + ' = require("' + conf.name + '");\n');
-  if (standalone) js.write('  } else {\n');
-  if (standalone) js.write('    module.exports = require("' + conf.name + '");\n');
-  if (standalone) js.write('  }\n');
-  if (standalone) js.write('})();');
+  if (program.separate) {
+    [{file: 'require.js', content: obj.require}].concat(obj.js)
+      .forEach(function (js, i) {
+      var out = fs.createWriteStream(path.join(program.out, i + '-' + js.file));
+      out.write(js.content);
+      if (program.verbose) log('write', out.path);
+    });
+
+    obj.css.forEach(function (css, i) {
+      var out = fs.createWriteStream(path.join(program.out, i + '-' + css.file));
+      out.write(css.content);
+      if (program.verbose) log('write', out.path);
+    });
+  } else {
+    var js = fs.createWriteStream(path.join(program.out, program.name + '.js'));
+    if (standalone) js.write(';(function(){\n');
+    js.write(obj.require);
+    js.write(obj.js);
+    if (standalone) js.write('  if ("undefined" == typeof module) {\n');
+    if (standalone) js.write('    window.' + name + ' = require("' + conf.name + '");\n');
+    if (standalone) js.write('  } else {\n');
+    if (standalone) js.write('    module.exports = require("' + conf.name + '");\n');
+    if (standalone) js.write('  }\n');
+    if (standalone) js.write('})();');
+    if (program.verbose) log('write', js.path);
+
+    var css = fs.createWriteStream(path.join(program.out, program.name + '.css'));
+    css.write(obj.css);
+    if (program.verbose) log('write', css.path);
+  }
 
   if (!program.verbose) return;
   var duration = new Date - start;
-  log('write', js.path);
-  log('write', css.path);
-  log('js', (obj.js.length / 1024 | 0) + 'kb');
-  log('css', (obj.css.length / 1024 | 0) + 'kb');
+  var jslength = program.separate ?
+    obj.js.map(function (js) { return js.content.length; }).reduce(function (a, b) { return a + b; }, 0) :
+    obj.js.length;
+  var csslength = program.separate ?
+    obj.css.map(function (css) { return css.content.length; }).reduce(function (a, b) { return a + b; }, 0) :
+    obj.css.length;
+  log('js', (jslength / 1024 | 0) + 'kb');
+  log('css', (csslength / 1024 | 0) + 'kb');
   log('duration', duration + 'ms');
   console.log();
 });

--- a/test/build.js
+++ b/test/build.js
@@ -10,6 +10,9 @@ var exec = require('child_process').exec
   , vm = require('vm')
 
 describe('component build', function(){
+  afterEach(function (done) {
+    exec('cd test/fixtures/path && rm -rf build', done);
+  });
   it('should build', function(done){
     exec('cd test/fixtures/path && ' + bin + '-build -v', function(err, stdout){
       if (err) return done(err);
@@ -24,6 +27,19 @@ describe('component build', function(){
 
       var ret = vm.runInNewContext(js + '; require("baz")');
       ret.should.equal('baz');
+
+      done();
+    })
+  })
+
+  it('should build separate files with --separate', function(done){
+    exec('cd test/fixtures/path && ' + bin + '-build -S -v', function(err, stdout){
+      if (err) return done(err);
+      stdout.should.include('build/0-require.js');
+      stdout.should.include('build/0-path-index.css');
+      stdout.should.include('duration');
+      stdout.should.include('css');
+      stdout.should.include('js');
 
       done();
     })

--- a/test/fixtures/path/component.json
+++ b/test/fixtures/path/component.json
@@ -4,5 +4,6 @@
     "bar": "*"
   },
   "scripts": ["index.js"],
+  "styles": ["index.css"],
   "paths": ["lib"]
 }

--- a/test/fixtures/path/index.css
+++ b/test/fixtures/path/index.css
@@ -1,0 +1,1 @@
+foo { bar: baz; }


### PR DESCRIPTION
Instead of building a monolithic `build.js` and `build.css`, this will create separate files which can be included for easier debugging in the browser.

The command line switch is -S --separate...
