### PR TITLE
Rename win-spawn to win-fork [fixes #170]

### DIFF
--- a/bin/component
+++ b/bin/component
@@ -6,7 +6,7 @@
 
 var program = require('commander')
   , utils = require('../lib/utils')
-  , spawn = require('win-spawn')
+  , spawn = require('win-fork')
   , path = require('path')
   , fs = require('fs')
   , join = path.join

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "string-to-js": "0.0.1",
     "jog": "0.4.0",
     "batch": "0.2.1",
-    "win-spawn": "0.0.0",
+    "win-fork": "1.0.0",
     "debug": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
I'm having trouble updating `win-spawn` as I created it using an old npm account, so `win-fork` is the same module but updated.  It should fix the remaining issues regarding using with windows.
