### PR TITLE
Component-Create: Uppercase Input

### DIFF
--- a/bin/component-create
+++ b/bin/component-create
@@ -149,8 +149,8 @@ program.prompt(prompt, function(obj){
  */
 
 function bool(str) {
-  return 'yes' == str
-    || 'y' == str;
+  return 'yes' == str.toLowerCase()
+    || 'y' == str.toLowerCase();
 }
 
 /**


### PR DESCRIPTION
When I first tried to use `component create` I was answering the questions with an uppercase "Y" and was confused why it didn't work. I just converted the string to lowercase to fix this.
