### PR TITLE
fixes #80: don't build css if there's no css

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -46,6 +46,7 @@ program.parse(process.argv);
 // load json
 
 var conf = require(path.resolve('component.json'));
+var hasCss = !!conf.styles && !!conf.styles.length;
 
 // standalone
 
@@ -58,7 +59,7 @@ mkdir.sync(program.out);
 // output streams
 
 var js = fs.createWriteStream(path.join(program.out, program.name + '.js'));
-var css = fs.createWriteStream(path.join(program.out, program.name + '.css'));
+var css = hasCss && fs.createWriteStream(path.join(program.out, program.name + '.css'));
 
 // build
 
@@ -90,9 +91,7 @@ builder.build(function(err, obj){
     ? standalone
     : conf.name;
 
-  obj.css.length
-    ? css.write(obj.css)
-    : fs.unlinkSync(css.path);
+  obj.css.length && css.write(obj.css);
 
   if (standalone) js.write(';(function(){\n');
   js.write(obj.require);


### PR DESCRIPTION
Per #80, If no CSS is written, removes empty css file and does not report file being written in --verbose output.

**ORIGINAL OUTPUT**

```
       write : build/build.js
       write : build/build.css
          js : 0kb
         css : 0kb
    duration : 3ms
```

**NEW OUTPUT**

```
       write : build/build.js
          js : 0kb
         css : 0kb
    duration : 6ms
```
