### PR TITLE
adds AMD support to --standalone

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -91,34 +91,25 @@ builder.build(function(err, obj){
     : conf.name;
 
   css.write(obj.css);
-  if (standalone) js.write(';(function(){\n');
-  js.write(obj.require);
-  js.write(obj.js);
 
   if (standalone) js.write(';(function(){\n');
   js.write(obj.require);
   js.write(obj.js);
-
-  var umd = [];
 
   if (standalone) {
-    umd = [
+    var umd = [
       'if (typeof exports == "object") {',
       '  module.exports = require("' + conf.name + '");',
       '} else if (typeof define == "function" && define.amd) {',
       '  define(require("' + conf.name + '"));',
       '} else {',
       '  window["' + name + '"] = require("' + conf.name + '");',
-      '}',
-      '\n'
+      '}'
     ];
+
+    js.write(umd.join('\n'));
+    js.write('})();');
   }
-
-  umd.forEach(function(line){
-    js.write('\n' + line);
-  });
-
-  if (standalone) js.write('})();');
 
   if (!program.verbose) return;
   var duration = new Date - start;


### PR DESCRIPTION
Per #139, adds AMD support to --standalone by way of a UMD module wrapper.

**ORIGINAL OUTPUT**

```
  if ("undefined" == typeof module) {
    window.attributes = require("validator");
  } else {
    module.exports = require("validator");
  }
```

**NEW OUTPUT**

```
if (typeof exports == "object") {
  module.exports = require("validator");
} else if (typeof define == "function" && define.amd) {
  define(require("validator"));
} else {
  window["validator"] = require("validator");
}
```
