### PR TITLE
Add correct version of installed dep to component.json

### DIFF
--- a/bin/component-install
+++ b/bin/component-install
@@ -94,7 +94,8 @@ if (local) {
 if (!local) {
   conf.dependencies = conf.dependencies || {};
   pkgs.forEach(function(pkg){
-    conf.dependencies[pkg] = '*';
+    pkg = parsePackage(pkg);
+    conf.dependencies[pkg.name] = pkg.version || '*';
   });
   saveConfig();
 }
@@ -108,11 +109,19 @@ conf.remotes.push('https://raw.github.com');
 
 console.log();
 pkgs.forEach(function(pkg){
-  var parts = pkg.split('@');
-  var name = parts.shift();
-  var version = parts.shift() || 'master';
-  install(name, version);
+  pkg = parsePackage(pkg);
+  install(pkg.name, pkg.version || 'master');
 });
+
+// parse package identifier
+
+function parsePackage(pkg) {
+  var parts = pkg.split('@');
+  return {
+    name: parts.shift(),
+    version: parts.shift()
+  };
+}
 
 // map deps to args
 

--- a/test/install.js
+++ b/test/install.js
@@ -40,10 +40,10 @@ describe('component install', function(){
     })
 
     it('should add the component to ./component.json', function(done){
-      exec('bin/component install component/emitter', function(err, stdout){
+      exec('bin/component install component/emitter@0.0.4', function(err, stdout){
         if (err) return done(err);
         var json = require(path.resolve('component.json'));
-        json.dependencies.should.have.property('component/emitter', '*');
+        json.dependencies.should.have.property('component/emitter', '0.0.4');
         done();
       })
     })


### PR DESCRIPTION
Currently, component install emitter@0.0.4 adds the dependency "component/emitter@0.0.4": "*" to component.json.

This patch ensures that the dependency added is ""component/emitter"": "0.0.4"
