### PR TITLE
Added an error incase the component.json file is missing the "name" attribute

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -47,6 +47,8 @@ program.parse(process.argv);
 
 var conf = require(path.resolve('component.json'));
 
+if(!conf.name) throw new Error("This component is missing a name.");
+
 // standalone
 
 var standalone = program.standalone;


### PR DESCRIPTION
otherwise, the build process seems to run fine but build.js will have 

``` javascript
    require.register("undefined/index.js", function(exports, require, module){
```
