### PR TITLE
Pull repo authorization info from .netrc

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -199,6 +199,24 @@ does this component have html? yes
   profile or session while developing component, otherwise `./bin/component`
   will have a hard time finding the sub-commands.
 
+## Using private components
+
+  `component(1)` uses [~/.netrc](http://man.cx/netrc(4), like other tools such as [curl](http://man.cx/curl) and [git](http://git-scm.com/), to specify credentials for remote hosts. Simply create a `~/.netrc` file in the home directory:
+
+```
+machine raw.github.com
+  login visionmedia
+  password pass123
+```
+
+  You may also use [GitHub OAuth Tokens](https://help.github.com/articles/creating-an-oauth-token-for-command-line-use) instead of your username and password. If my token were `testing123` my `~/.netrc` file would look like the following:
+
+```
+machine raw.github.com
+  login testing123
+  password x-oauth-basic
+```
+
 ## Running tests
 
 Make sure dependencies are installed:

--- a/lib/Package.js
+++ b/lib/Package.js
@@ -11,6 +11,7 @@ var Emitter = require('events').EventEmitter
   , join = path.join
   , mkdir = require('mkdirp').mkdirp
   , request = require('superagent')
+  , netrc = require('netrc')
   , debug = require('debug')('component:installer')
   , Batch = require('batch')
   , http = require('http')
@@ -56,6 +57,7 @@ function Package(pkg, version, options) {
   this.dest = options.dest || 'components';
   this.remotes = options.remotes || ['https://raw.github.com'];
   this.auth = options.auth;
+  this.netrc = netrc(options.netrc);
   this.force = !! options.force;
   this.version = version;
   if (inFlight[this.slug]) this.install = function(){};
@@ -161,6 +163,10 @@ Package.prototype.getJSON = function(fn){
   var req = request.get(url);
   req.set('Accept-Encoding', 'gzip');
 
+  // authorize call
+  var netrc = self.netrc[self.remote.host];
+  if (netrc) req.auth(netrc.login, netrc.password);
+
   req.end(function(res){
     if (res.error) return fn(error(res, url));
     try {
@@ -207,6 +213,9 @@ Package.prototype.getFiles = function(files, fn){
         req.set('Accept-Encoding', 'gzip');
         req.buffer(false);
 
+        // authorize call
+        var netrc = self.netrc[self.remote.host];
+        if (netrc) req.auth(netrc.login, netrc.password);
         if (self.auth) req.auth(self.auth.user, self.auth.pass);
 
         req.end(function(res){

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "batch": "0.2.1",
     "win-fork": "1.0.0",
     "archy": "0.0.2",
+    "netrc": "~0.1.0",
     "debug": "*"
   },
   "devDependencies": {


### PR DESCRIPTION
Using the [.netrc](http://linux.die.net/man/5/netrc) file will allow you to use an [OAuth token](https://github.com/blog/1270-easier-builds-and-deployments-using-git-over-https-and-oauth) to authenticate for private repositories without hard-coding in the user credentials into the component.json. This is what mine looks like:

```
machine raw.github.com
  login {MY_GITHUB_OAUTH_TOKEN}
  password x-oauth-basic
```

It has several benefits:
- better for security
- you don't have to add another remote; just use it as if it were public
- share the repos across an organization with different creds
- revoke access on any token if compromised
