### PR TITLE
Fix AMD loading

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -101,7 +101,7 @@ builder.build(function(err, obj){
       'if (typeof exports == "object") {',
       '  module.exports = require("' + conf.name + '");',
       '} else if (typeof define == "function" && define.amd) {',
-      '  define(require("' + conf.name + '"));',
+      '  define(function () { return require("' + conf.name + '"); });',
       '} else {',
       '  window["' + name + '"] = require("' + conf.name + '");',
       '}'


### PR DESCRIPTION
Component produces invalid standalone AMD builds if the main export is a function. This commit fixes this by wrapping the export in a function which is always the desired value that requirejs for example expects.
