### PR TITLE
inFlight requests do not emit `end` events

### DIFF
--- a/lib/Package.js
+++ b/lib/Package.js
@@ -58,7 +58,9 @@ function Package(pkg, version, options) {
   this.auth = options.auth;
   this.force = !! options.force;
   this.version = version;
-  if (inFlight[this.slug]) this.install = function(){};
+  if (inFlight[this.slug]) this.install = function(){
+    this.emit('end');
+  };
   inFlight[this.slug] = true;
 }
 


### PR DESCRIPTION
changes based on #47 ... `end` events can no longer be counted on... this immediately throws an end event.

the other alternative would be to do a process.nextTick -> emit 'exists'

however you like...
