### PR TITLE
install: do not create component.json if it doesn't exist

### DIFF
--- a/bin/component-install
+++ b/bin/component-install
@@ -102,7 +102,9 @@ if (!local) {
     pkg = parsePackage(pkg);
     conf.dependencies[pkg.name] = pkg.version || '*';
   });
-  saveConfig();
+  if (exists('component.json')) {
+    saveConfig();
+  }
 }
 
 // implicit remotes


### PR DESCRIPTION
Annoys when you install to a not boot component dir.
