### PR TITLE
Custom Remote Paths

### DIFF
--- a/bin/component-install
+++ b/bin/component-install
@@ -118,7 +118,12 @@ if (program.remotes) {
 
 // default to github
 
-conf.remotes.push('https://raw.github.com');
+if( Array.isArray(conf.remotes) ) {
+  conf.remotes.push('https://raw.github.com');  
+}
+else {
+  conf.remotes['https://raw.github.com'] = "/{name}/{version}/{file}";
+}
 
 // install
 

--- a/lib/Package.js
+++ b/lib/Package.js
@@ -54,7 +54,8 @@ function Package(pkg, version, options) {
   this.name = pkg;
   this.slug = pkg + '@' + version;
   this.dest = options.dest || 'components';
-  this.remotes = options.remotes || ['https://raw.github.com'];
+  this.remoteTemplates = options.remoteTemplates || {};
+  this.remotes = this.normalizeRemotes(options.remotes) || ['https://raw.github.com'];
   this.auth = options.auth;
   this.force = !! options.force;
   this.version = version;
@@ -102,7 +103,27 @@ Package.prototype.join = function(path){
  */
 
 Package.prototype.url = function(file){
-  return this.remote.href + '/' + this.name + '/' + this.version + '/' + file;
+  var path = this.remoteTemplates[this.remote.href] || '/{name}/{version}/{file}';
+  path = path.replace('{name}', this.name);
+  path = path.replace('{version}', this.version);
+  path = path.replace('{file}', file);
+  return this.remote.href + path;
+};
+
+/**
+ * Normalize the remotes so that we can pass in either an
+ * array of URLs that use the github-style paths or an object
+ * with custom paths defined.
+ *
+ * @param {Object} remotes
+ * @return {Array}
+ * @api private
+ */
+
+Package.prototype.normalizeRemotes = function(remotes){
+  if(Array.isArray(remotes)) return remotes;
+  this.remoteTemplates = remotes;
+  return Object.keys(remotes);
 };
 
 /**
@@ -255,7 +276,8 @@ Package.prototype.getDependencies = function(deps, fn){
       var pkg = new Package(name, version, {
         dest: self.dest,
         force: self.force,
-        remotes: self.remotes
+        remotes: self.remotes,
+        remoteTemplates: self.remoteTemplates
       });
       self.emit('dep', pkg);
       pkg.on('end', done);


### PR DESCRIPTION
Pull-request for issue #286

This allows you to set paths in the remote section of the manifest for custom URL paths:

``` json
{
   "remotes": {
      "https://privateserver": "/{name}/blobs/raw/{version}/{file}"
   }
}
```

**While still letting you use the array list of remotes as before.** If you use an array of remotes it will use the default 'template' of `/{name}/{version}/{file}` — aka the github-style.

Primary use case for this is for git servers that don't use the github URLs. This means you could use Component with Bitbucket (I think) and Gitorious, which is great for setting up an internal registry of components.
