### PR TITLE
build: Allow for custom location for installed components to be specified

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -19,6 +19,7 @@ var program = require('commander')
 program
   .option('-d, --dev', 'build development dependencies')
   .option('-s, --standalone <name>', 'build a stand-alone version of the component')
+  .option('-i, --in <dir>', 'input directory for components to be built (--out from component-install)', 'components')
   .option('-o, --out <dir>', 'output directory defaulting to ./build', 'build')
   .option('-n, --name <file>', 'base name for build files defaulting to build', 'build')
   .option('-v, --verbose', 'output verbose build information')
@@ -77,6 +78,7 @@ if (program.copy) builder.copyFiles();
 builder.copyAssetsTo(program.out);
 if (program.dev) builder.prefixUrls('./');
 if (program.prefix) builder.prefixUrls(program.prefix);
+if (program.in) builder.paths[0] = program.in;
 
 // lookup paths
 


### PR DESCRIPTION
Currently, there is no way to translate a custom `--out` parameter from the **install** command to the **build** command. This PR adds the option `--in` to **build** that should act as that bridge. (thus, allowing a custom location to be specified for the installed components that are awaiting being built)
