### PR TITLE
Using the current remote to get the file path

### DIFF
--- a/lib/Package.js
+++ b/lib/Package.js
@@ -102,7 +102,7 @@ Package.prototype.join = function(path){
  */
 
 Package.prototype.url = function(file){
-  return this.remotes[0] + '/' + this.name + '/' + this.version + '/' + file;
+  return this.remote.href + '/' + this.name + '/' + this.version + '/' + file;
 };
 
 /**


### PR DESCRIPTION
Component is currently using the first remote to try and fetch each file meaning you can't specify multiple remotes. This fixes that and means it will use the current remote to build the url.
