### PR TITLE
Exit code now being passed

### DIFF
--- a/bin/component
+++ b/bin/component
@@ -73,3 +73,7 @@ if (exists(local)) bin = local;
 // spawn
 
 var proc = spawn(bin, args, { stdio: 'inherit', customFds: [0, 1, 2] });
+// Pass the exit code upon 'close' of the child process
+proc.on('close', function(code) {
+  process.exit(code);
+});


### PR DESCRIPTION
This was not happening before and would mean that failed executions of `component build` would not set the status code on the shell. This is particularly annoying when relying on Makefiles to handle a complicated build step. If the any of the component commands failed make would simply glide over it as if nothing happened.
