### PR TITLE
Added option to exclude require implementation from build

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -25,6 +25,7 @@ program
   .option('-p, --prefix <str>', 'prefix css asset urls with <str>')
   .option('-c, --copy', 'copy files instead of linking')
   .option('-u, --use <name>', 'use the given build plugin(s)')
+  .option('-e, --excluderequire', 'exclude require from build')
 
 // examples
 
@@ -60,6 +61,10 @@ var conf = require(path.resolve('component.json'));
 // standalone
 
 var standalone = program.standalone;
+
+// exclude require implementation
+
+var excluderequire = program.excluderequire;
 
 // output paths
 
@@ -112,7 +117,7 @@ builder.build(function(err, obj){
     : conf.name;
 
   if (standalone) js += ';(function(){\n';
-  js += obj.require;
+  if (!excluderequire) js += obj.require;
   js += obj.js;
 
   if (standalone) {


### PR DESCRIPTION
Yesterday, I opened component/builder.js#90 in the wrong repo, apologies for that.

Figured out I could easily create such a build (without the require implementation) myself just by not including `res.require`.

Still, I think it deserves the `-e` option in `component-builder` to do the same from CLI, so here is a PR for that.
