### PR TITLE
add .demo

### DIFF
--- a/bin/component-search
+++ b/bin/component-search
@@ -102,7 +102,7 @@ function verbose(pkgs) {
     console.log('  \033[36m%s\033[m', pkg.repo.toLowerCase());
     console.log('  url: \033[90mhttps://github.com/%s\033[m', pkg.repo);
     console.log('  desc: \033[90m%s\033[m', description(pkg.description));
-    if (program.verbose) console.log('  demo: \033[90m%s\033[m', demo(pkg) || 'none');
+    if (program.verbose) console.log('  demo: \033[90m%s\033[m', pkg.demo || 'none');
     if (program.verbose) console.log('  version: \033[90m%s\033[m', pkg.version);
     if (program.verbose) console.log('  license: \033[90m%s\033[m', pkg.license || 'none');
     console.log('  ★ \033[90m%s\033[m', pkg.stars);
@@ -123,20 +123,6 @@ function json(pkgs) {
     if (i < len - 1) process.stdout.write(',\n');
   });
   console.log(']');
-}
-
-/**
- * get demo url.
- */
-
-function demo(pkg){
-  if ('gh-pages' != pkg.demo) return pkg.demo;
-  var parts = pkg.repo.split('/');
-  return 'http://'
-    + parts[0]
-    + '.github.io/'
-    + parts[1]
-    + '/index.html';
 }
 
 /**


### PR DESCRIPTION
the way it works is if you have say:

``` json
{
  "repo": "component/swipe",
  "demo": "gh-pages"
}
```

it will automatically show http://component.github.io/swipe/index.html, otherwise it just shows whatever is in `.demo`, if it's missing it just outputs `none`.
