### PR TITLE
Improve build's error reporting for error objects with no .message

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -104,7 +104,7 @@ if (program.dev) {
 
 if (program.verbose) console.log();
 builder.build(function(err, obj){
-  if (err) utils.fatal(err.message);
+  if (err) utils.fatal(err.message || err);
   var js = '';
   var css = obj.css.trim();
 


### PR DESCRIPTION
fs.lstat raises an error with no .message attr - default to just outputting the whole error.

I ran into this while doing `component build -c` with a file referenced in the component.json that did not exist. Since fstat's error has not .message attribute, all I got was "error: undefined" ... took me a while to figure it out.
