### PR TITLE
fixes non-fatal error output for component-install

### DIFF
--- a/bin/component-install
+++ b/bin/component-install
@@ -159,6 +159,8 @@ function report(pkg, options) {
       error(err.message);
       process.exit(1);
     }
+
+    error(err.message);
   });
 
   if (program.verbose) {

--- a/test/install.js
+++ b/test/install.js
@@ -27,6 +27,14 @@ describe('component install', function(){
   })
 
   describe('[name]', function(){
+    it('should show an error message if the component is named incorrectly', function(done) {
+      exec('bin/component install component-emitter', function(err, stdout) {
+        if(err) return done(err);
+        stdout.should.include('install');
+        done();
+      })
+    })
+
     it('should install a single component', function(done){
       exec('bin/component install component/emitter', function(err, stdout){
         if (err) return done(err);


### PR DESCRIPTION
I noticed no errors were showing up for `component install`, I chose not to throw since these are non-fatal errors and the installation of other components can continue.

Let me know if I should add anything else.
