### PR TITLE
Allow require.js optimizer to run on standalone builds.

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -121,7 +121,7 @@ builder.build(function(err, obj){
       'if (typeof exports == "object") {',
       '  module.exports = require("' + conf.name + '");',
       '} else if (typeof define == "function" && define.amd) {',
-      '  define(function(){ return require("' + conf.name + '"); });',
+      '  define(require("' + conf.name + '"));',
       '} else {',
       '  this["' + name + '"] = require("' + conf.name + '");',
       '}'


### PR DESCRIPTION
## tl;dr

I'm seeing build errors when I try and produce an optimized build with component's current AMD define block. This fixes it. 

I didn't see any tests for the standalone behavior, so I didn't add any new ones.

---

When performing optimization require.js looks inside of define blocks for require calls (to allow for CJS-esque requires inside of AMD blocks).

It sees the call to component's `require` inside of the define, confuses it for a require.js `require`, says "I don't see that file!" then explodes.
