### PR TITLE
Node v0.10+ with Local Dependencies breaks with v0.16.4

### DIFF
--- a/lib/component.js
+++ b/lib/component.js
@@ -67,7 +67,9 @@ exports.dependenciesOf = function(pkg, paths, parent){
   var deps = [conf.dependencies || {}];
 
   if (conf.local) {
-    var localPaths = (conf.paths || []).map(resolve.bind(null, path));
+    var localPaths = (conf.paths || []).map(function (depPath) {
+      return resolve(path, depPath);
+    });
     conf.local.forEach(function(dep){
       deps = deps.concat(exports.dependenciesOf(dep, paths.concat(localPaths), pkg));
     });


### PR DESCRIPTION
When installing with local dependencies, I get the "arguments to path.resolve must be strings error" that was introduced with Node v0.10. This PR corrects this fatal error.
