### PR TITLE
`component install` does not work on node < 0.9.4

### DIFF
--- a/lib/Package.js
+++ b/lib/Package.js
@@ -234,12 +234,12 @@ Package.prototype.getFiles = function(files, fn){
         if (netrc) req.auth(netrc.login, netrc.password);
         if (self.auth) req.auth(self.auth.user, self.auth.pass);
 
-        req.end(function(res){
-          if (res.error) return done(error(res, url));
-          res.pipe(fs.createWriteStream(dst));
-          res.on('error', done);
-          res.on('end', done);
-        });
+        req
+        .on('end', done)
+        .on('error', done)
+        .pipe(fs.createWriteStream(dst))
+        .on('error', done)
+
       });
     });
   });

--- a/test/install.js
+++ b/test/install.js
@@ -74,6 +74,16 @@ describe('component install', function(){
         done();
       })
     })
+    it('should download files completely', function(done){
+      exec('bin/component install timoxley/font-awesome@3.2.1', function(err, stdout){
+        if (err) return done(err);
+        var stats = fs.statSync(path.resolve('components/timoxley-font-awesome/font/fontawesome-webfont.woff'));
+        stats.size.should.equal(43572);
+        stdout.should.include('install');
+        stdout.should.include('complete');
+        done();
+      })
+    })
   })
 
   describe('[name...]', function(){


### PR DESCRIPTION
edit: I originally thought this was an OSX/Linux issue, I've now discovered it's more likely node version issue.

It fails at least with component [timoxley/font-awesome](http://github.com/timoxley/font-awesome/)
trying to `component install` on node < 0.9.4, fails to fully download files, but doesn't error.

I've tested it fails for:
- 0.8.22
- 0.8.24
- 0.8.25
- 0.9.0
- 0.9.2
- 0.9.3

and starts working at:
- 0.9.4

e.g.

On Node 0.10.5:

```
-rw-r--r--  1 timoxley  staff   37405 29 Jun 15:05 fontawesome-webfont.eot
-rw-r--r--  1 timoxley  staff  197829 29 Jun 15:05 fontawesome-webfont.svg
-rw-r--r--  1 timoxley  staff   79076 29 Jun 15:05 fontawesome-webfont.ttf
-rw-r--r--  1 timoxley  staff   43572 29 Jun 15:05 fontawesome-webfont.woff
```

But on Node 0.8.22, you'll notice the byte sizes are all messed up:

```
-rw-r--r-- 1 root root  7336 Jul  2 12:59 fontawesome-webfont.eot 
-rw-r--r-- 1 root root 25165 Jul  2 12:59 fontawesome-webfont.svg
-rw-r--r-- 1 root root  7338 Jul  2 12:59 fontawesome-webfont.ttf
-rw-r--r-- 1 root root  7343 Jul  2 12:59 fontawesome-webfont.woff
```
