### PR TITLE
Clean up spawn error when sub-command not found

### DIFF
--- a/bin/component
+++ b/bin/component
@@ -10,7 +10,9 @@ var spawn = require('win-fork');
 var path = require('path');
 var fs = require('fs');
 var join = path.join;
+var stat = fs.statSync;
 var exists = fs.existsSync;
+var resolve = path.resolve;
 
 // usage
 
@@ -60,10 +62,22 @@ if (!cmd) program.help();
 
 var bin = 'component-' + cmd;
 
-// local
+// local or resolve to absolute executable path
 
 var local = join(__dirname, bin);
-if (exists(local)) bin = local;
+
+if (exists(local)) {
+  bin = local;
+} else {
+  bin = process.env.PATH.split(':').reduce(function(binary, p) {
+    p = resolve(p, bin);
+    return exists(p) && stat(p).isFile() ? p : binary;
+  }, bin);
+}
+
+// display help if bin does not exist
+
+if (!exists(bin)) program.help();
 
 // spawn
 


### PR DESCRIPTION
Currently when `component` attempts to spawn a sub-command not found in the users path it outputs:

``` shell
execvp(): No such file or directory

events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: spawn ENOENT
    at errnoException (child_process.js:975:11)
    at Process.ChildProcess._handle.onexit (child_process.js:766:34)
```

Changed this to display the default help message, provided by `program.help()`, when an absolute path to the executable cannot be found. Duplicate executables within a user's path are resolved to the last entry.
