### PR TITLE
Keep duplicate github remotes from being added to component.json

### DIFF
--- a/bin/component-install
+++ b/bin/component-install
@@ -105,10 +105,6 @@ if (program.remotes) {
   conf.remotes = program.remotes.split(',').concat(conf.remotes);
 }
 
-// default to github
-
-conf.remotes.push('https://raw.github.com');
-
 // install
 
 console.log();
@@ -205,7 +201,7 @@ function install(name, version) {
     dest: program.out,
     force: program.force,
     dev: program.dev,
-    remotes: conf.remotes,
+    remotes: conf.remotes.concat('https://raw.github.com'), // default to github
     concurrency: 10
   });
 


### PR DESCRIPTION
My pull request #387 was causing the default GitHub remote to be added to `component.json`; causing duplicates with multiple calls to `component install`. This is because before my pull request `saveConfig` was called before the default remote as was added. Also as far as I can tell, since we're using `end` event for each package to write the file, the `forEach` loop is unneeded now. `pkg.version` gets set to `master` so there is check performed to change it to `*` I added commits to fix both of these problems and I read the file over to make sure it wasn't breaking anything else. As far as I can tell everything is right now.
