### PR TITLE
Adding proxy support

### DIFF
--- a/bin/component-install
+++ b/bin/component-install
@@ -23,6 +23,7 @@ program
   .option('-r, --remotes <urls>', 'remotes to try installing from')
   .option('-o, --out <dir>', 'output components to the given <dir>', 'components')
   .option('-f, --force', 'force installation even if previously installed')
+  .option('-p, --proxy', 'use a proxy, eg. http://localhost:3128')
   .option('-v, --verbose', 'verbose output')
 
 // examples
@@ -201,6 +202,7 @@ function install(name, version) {
     dest: program.out,
     force: program.force,
     dev: program.dev,
+    proxy: program.proxy,
     remotes: conf.remotes.concat('https://raw.github.com'), // default to github
     concurrency: 10
   });

--- a/lib/Package.js
+++ b/lib/Package.js
@@ -22,6 +22,12 @@ var http = require('http');
 var https = require('https');
 
 /**
+ * Extend superagent with proxy support
+ */
+
+require('superagent-proxy')(request);
+
+/**
  * In-flight requests.
  */
 
@@ -62,6 +68,7 @@ function Package(pkg, version, options) {
   this.auth = options.auth;
   this.netrc = netrc(options.netrc);
   this.force = !! options.force;
+  this.proxy = options.proxy || process.env.https_proxy;
   this.version = version;
   this.concurrency = options.concurrency;
   if (inFlight[this.slug]) {
@@ -181,6 +188,9 @@ Package.prototype.getJSON = function(fn){
   var req = request.get(url);
   req.set('Accept-Encoding', 'gzip');
 
+  // Add proxy
+  if(self.proxy) req.proxy(self.proxy);
+
   // authorize call
   var netrc = self.netrc[parse(url).hostname];
   if (netrc) req.auth(netrc.login, netrc.password);
@@ -231,6 +241,7 @@ Package.prototype.getFiles = function(files, fn){
         // TODO: add netrc stuff back
         // TODO: add gzip support back
         var req = self.request(url);
+
         req.on('error', done);
         req.on('response', function(res){
           if (200 != res.statusCode) return done(error(res, url));
@@ -309,7 +320,8 @@ Package.prototype.getDependencies = function(deps, fn){
       var pkg = new Package(name, version, {
         dest: self.dest,
         force: self.force,
-        remotes: self.remotes
+        remotes: self.remotes,
+        proxy: self.proxy
       });
       self.emit('dep', pkg);
       pkg.on('end', done);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "archy": "0.0.2",
     "netrc": "~0.1.0",
     "debug": "*",
-    "rimraf": "~2.1.4"
+    "rimraf": "~2.1.4",
+    "superagent-proxy": "0.0.1"
   },
   "devDependencies": {
     "express": "3.0.0",


### PR DESCRIPTION
It's probably about time we added proxy support to Component. This pull request doesn't cover everything but it's a start.

I'm stuck inside an enterprise network at work (yay for windows... _cough_) so I need to do some funky workarounds on my machine to get things to work. I'm sure more people are as well and it's really not that hard to get some basic proxy support working.

superagent-proxy seems to do a easy job of adding proxy support to superagent. I have little experience in this area, so if someone who knows what they're doing has a better idea, I'm all for it.
