### PR TITLE
Bumped version of netrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Component package manager consuming git repositories",
   "keywords": [
     "component",
@@ -21,7 +21,7 @@
     "batch": "0.3.2",
     "win-fork": "1.0.0",
     "archy": "0.0.2",
-    "netrc": "~0.1.0",
+    "netrc": "~0.1.3",
     "debug": "*",
     "rimraf": "~2.1.4"
   },


### PR DESCRIPTION
Previous version of netrc had issues on Windows if the HOME environment var wasn't set. Some guys at work using Windows were having issues installing. This should fix it.
