### PR TITLE
considering that superagent mimics req behavior it is reasonable to have...

### DIFF
--- a/lib/Package.js
+++ b/lib/Package.js
@@ -1,4 +1,3 @@
-
 /**
  * Module dependencies.
  */
@@ -249,7 +248,7 @@ Package.prototype.getFiles = function(files, fn){
         if (self.auth) req.auth(self.auth.user, self.auth.pass);
 
         req
-        .on('end', done)
+        .on('close', done)
         .on('error', done)
         .pipe(fs.createWriteStream(dst))
         .on('error', done);


### PR DESCRIPTION
... on close instead of on end

I am using Package to install components. And I use my custom installer that takes callback. I am taking callback package.on('end') and I have a bug where files are not uploaded yet and the package is done.
I believe that it's caused because supergent's end is too early. Before the data actually piped into file.
on close event is better here. At least it fixes my bug.
