### PR TITLE
Adding parameter to prevent Common.js loaders

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -19,7 +19,7 @@ var mkdir = require('mkdirp');
 program
   .option('-d, --dev', 'build development dependencies')
   .option('-s, --standalone <name>', 'build a stand-alone version of the component')
-  .option('-g, --global', 'when building stand-alone, build without common.js loaders')
+  .option('-g, --global', 'build a stand-alone version without common.js loaders')
   .option('-o, --out <dir>', 'output directory defaulting to ./build', 'build')
   .option('-n, --name <file>', 'base name for build files defaulting to build', 'build')
   .option('-p, --prefix <str>', 'prefix css asset urls with <str>')
@@ -43,7 +43,7 @@ program.on('--help', function(){
   console.log('    $ component build --standalone $');
   console.log();
   console.log('    # when standalone, build without common.js loaders');
-  console.log('    $ component build --standalone $ --global');
+  console.log('    $ component build --global');
   console.log();
   console.log('    # build with plugins');
   console.log('    $ component build -u foo,bar,baz');
@@ -121,12 +121,12 @@ builder.build(function(err, obj){
     if (program.require) js += obj.require;
     js += obj.js;
 
-    if (standalone) {
-      if (program.global) {
+    // Both included here in case they use both
+    if (standalone || global) {
+      if (global) {
         js += '\n\nthis["' + name + '"] = require("' + conf.name + '");\n';
       } else {
         var umd = [
-          '\n',
           'if (typeof exports == "object") {',
           '  module.exports = require("' + conf.name + '");',
           '} else if (typeof define == "function" && define.amd) {',


### PR DESCRIPTION
For when working in legacy code that has incompatible `exports` object, or for any other reason when you would want the code to not attempt to be `require`-loaded or `amd`-loaded.
