### PR TITLE
correctly fetch json files

### DIFF
--- a/lib/Package.js
+++ b/lib/Package.js
@@ -408,6 +408,7 @@ Package.prototype.reallyInstall = function(){
       if (json.files) files = files.concat(json.files);
       if (json.images) files = files.concat(json.images);
       if (json.fonts) files = files.concat(json.fonts);
+      if (json.json) files = files.concat(json.json);
       json.repo = json.repo || self.remote.href + '/' + self.name;
 
       if (json.dependencies) {

--- a/test/install.js
+++ b/test/install.js
@@ -85,6 +85,17 @@ describe('component install', function(){
         done();
       })
     })
+
+    it('should also download json files', function (done) {
+      exec('bin/component install Swatinem/t', function(err, stdout){
+        if (err) return done(err);
+        var exists = fs.existsSync(path.resolve('components/Swatinem-t/lib/definitions.json'));
+        exists.should.be.true;
+        stdout.should.include('install');
+        stdout.should.include('complete');
+        done();
+      })
+    })
   })
 
   describe('[name...]', function(){


### PR DESCRIPTION
json support in builder is pretty useless if `component install` doesn’t fetch the json files.
