### PR TITLE
Package: re-implement the .netrc auth logic

### DIFF
--- a/lib/Package.js
+++ b/lib/Package.js
@@ -191,8 +191,9 @@ Package.prototype.getJSON = function(fn){
   if (this.proxy) req.proxy(this.proxy);
 
   // authorize call
-  var netrc = this.netrc[parse(url).hostname];
-  if (netrc) req.auth(netrc.login, netrc.password);
+  var hostname = parse(url).hostname;
+  var auth = encodeAuth(this, hostname);
+  if (auth) req.set('Authorization', auth);
 
   req.end(function(res){
     if (res.error) return fn(error(res, url));
@@ -238,7 +239,6 @@ Package.prototype.getFiles = function(files, fn){
       self.mkdir(dirname(dst), function(err){
         if (err) return done(err);
 
-        // TODO: add netrc stuff back
         // TODO: add gzip support back
         var req = self.request(url);
 
@@ -282,7 +282,15 @@ Package.prototype.getFiles = function(files, fn){
 
 Package.prototype.request = function(url){
   var mod = 0 == url.indexOf('https://') ? https : http;
+  var headers = {};
   var opts = parse(url);
+
+  // authorize call
+  var hostname = opts.hostname;
+  var auth = encodeAuth(this, hostname);
+  if (auth) headers.Authorization = auth;
+
+  opts.headers = headers;
   return mod.get(opts);
 };
 
@@ -460,4 +468,26 @@ function error(res, url) {
   var err = new Error('failed to fetch ' + url + ', got ' + res.statusCode + ' "' + name + '"');
   err.status = res.statusCode;
   return err;
+}
+
+/**
+ * Returns an HTTP Basic auth header string, either from being manually
+ * passed in credentials or from the .netrc file, or `null` if no
+ * authentication information is found.
+ *
+ * @param {Package} pkg
+ * @param {String} hostname
+ * @return {String}
+ * @api private
+ */
+
+function encodeAuth(pkg, hostname) {
+  var str = null;
+  var auth = pkg.auth || pkg.netrc[hostname];
+  if (auth) {
+    var u = auth.user || auth.username || auth.login;
+    var p = auth.pass || auth.password;
+    str = 'Basic ' + new Buffer(u + ':' + p).toString('base64');
+  }
+  return str;
 }


### PR DESCRIPTION
Support for the .netrc auth was removed in 6a04a0c.

Now the auth encoding logic is normalized into an external function,
which both the .getFile() and .getJSON() functions use.

As an added bonus, manually passed in auth credentials now work with .getJSON().
Previously only the .netrc file would be accounted for.
