### PR TITLE
added support for local development deps using component install --dev

### DIFF
--- a/bin/component-install
+++ b/bin/component-install
@@ -84,7 +84,7 @@ if (local) {
   if (conf.local) {
     conf.local.forEach(function(pkg){
       try {
-        var deps = component.dependenciesOf(pkg, conf.paths);
+        var deps = component.dependenciesOf(pkg, conf.paths, undefined, program.dev);
         deps.map(normalize).forEach(function(deps){
           pkgs = pkgs.concat(deps);
         });

--- a/lib/component.js
+++ b/lib/component.js
@@ -58,13 +58,16 @@ exports.lookup = function(pkg, paths){
  * @api private
  */
 
-exports.dependenciesOf = function(pkg, paths, parent){
+exports.dependenciesOf = function(pkg, paths, parent, dev){
   paths = paths || [];
   var path = exports.lookup(pkg, paths);
   if (!path && parent) throw new Error('failed to lookup "' + parent + '"\'s dep "' + pkg + '"');
   if (!path) throw new Error('failed to lookup "' + pkg + '"');
   var conf = require(resolve(path, 'component.json'));
   var deps = [conf.dependencies || {}];
+  if(!!dev && conf.development) {
+      deps = deps.concat(conf.development);
+  }
 
   if (conf.local) {
     var localPaths = (conf.paths || []).map(function(depPath){
@@ -72,7 +75,7 @@ exports.dependenciesOf = function(pkg, paths, parent){
     });
 
     conf.local.forEach(function(dep){
-      deps = deps.concat(exports.dependenciesOf(dep, paths.concat(localPaths), pkg));
+      deps = deps.concat(exports.dependenciesOf(dep, paths.concat(localPaths), pkg, dev));
     });
   }
 

--- a/test/fixtures/local/others/first/component.json
+++ b/test/fixtures/local/others/first/component.json
@@ -5,6 +5,9 @@
   "dependencies": {
     "component/overlay": "*"
   },
+  "development":{
+    "chaijs/chai":"*"
+  },
   "main": "index.js",
   "scripts": [
     "index.js"

--- a/test/install.js
+++ b/test/install.js
@@ -75,6 +75,15 @@ describe('component install', function(){
       })
     })
 
+    it('should install development dependencies through chain of local dependencies', function(done){
+      var proc = exec('cd test/fixtures/local && ../../../bin/component install --dev', function(err, stdout){
+        if (err) return done(err);
+        var exists = fs.existsSync(path.resolve(__dirname, 'fixtures','local','components','chaijs-chai'));
+        exists.should.be.true
+        done();
+      })
+    })
+
     it('should download files completely', function(done){
       exec('bin/component install timoxley/font-awesome@3.2.1', function(err, stdout){
         if (err) return done(err);


### PR DESCRIPTION
This forwards the --dev flag during install so that subcomponents' `development` config will be respected.
