### PR TITLE
create: include full MIT license

### DIFF
--- a/bin/component-create
+++ b/bin/component-create
@@ -130,6 +130,7 @@ program.prompt(prompt, function(obj){
   if (!local) write(join(dir, 'Makefile'), createMakefile(obj));
 
   // readme
+  obj.year = new Date().getUTCFullYear().toString();
   if (!local) write(join(dir, 'Readme.md'), readme(obj));
 
   // changelog

--- a/templates/readme.js
+++ b/templates/readme.js
@@ -1,4 +1,5 @@
-module.exports = function anonymous(obj) {
+module.exports = function anonymous(obj
+/**/) {
 
   function escape(html) {
     return String(html)
@@ -16,5 +17,5 @@ module.exports = function anonymous(obj) {
     return '';
   };
 
-  return "\n# " + escape(obj.name) + "\n\n  " + escape(obj.desc) + "\n\n## Installation\n\n  Install with [component(1)](http://component.io):\n\n    $ component install " + escape(obj.repo) + "\n\n## API\n\n\n\n## License\n\n  MIT\n"
+  return "\n# " + escape(obj.name) + "\n\n  " + escape(obj.desc) + "\n\n## Installation\n\n  Install with [component(1)](http://component.io):\n\n    $ component install " + escape(obj.repo) + "\n\n## API\n\n\n\n## License\n\n  The MIT License (MIT)\n\n  Copyright (c) " + escape(obj.year) + " <copyright holders>\n\n  Permission is hereby granted, free of charge, to any person obtaining a copy\n  of this software and associated documentation files (the \"Software\"), to deal\n  in the Software without restriction, including without limitation the rights\n  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n  copies of the Software, and to permit persons to whom the Software is\n  furnished to do so, subject to the following conditions:\n\n  The above copyright notice and this permission notice shall be included in\n  all copies or substantial portions of the Software.\n\n  THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n  THE SOFTWARE."
 }

--- a/templates/readme.md
+++ b/templates/readme.md
@@ -15,4 +15,24 @@
 
 ## License
 
-  MIT
+  The MIT License (MIT)
+
+  Copyright (c) {year} <copyright holders>
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.


### PR DESCRIPTION
you're supposed to include the entire MIT license. this will also avoid those PRs that are like "plz include license". we could also just add a `LICENSE` file, but I prefer it being in the readme.
