### PR TITLE
Update wrapper to prevent unintended circular dependencies

### DIFF
--- a/bin/component-build
+++ b/bin/component-build
@@ -122,7 +122,7 @@ builder.build(function(err, obj){
         'if (typeof exports == "object") {',
         '  module.exports = require("' + conf.name + '");',
         '} else if (typeof define == "function" && define.amd) {',
-        '  define(function(){ return require("' + conf.name + '"); });',
+        '  define([], function(){ return require("' + conf.name + '"); });',
         '} else {',
         '  this["' + name + '"] = require("' + conf.name + '");',
         '}'


### PR DESCRIPTION
The wrapper code could cause circular dependencies for AMD loaders.
It doesn't include a dependencies argument in the call to
define, which will cause some loaders to scan the factory function for
require calls.
