### PR TITLE
Added to template property instead of scripts for templates.

### DIFF
--- a/bin/component-create
+++ b/bin/component-create
@@ -115,8 +115,7 @@ program.prompt(prompt, function(obj){
 
   // html
   if (bool(obj.html)) {
-    conf.scripts = conf.scripts || [];
-    conf.scripts.push('template.js');
+    conf.templates = ['template.html'];
     write(join(dir, 'template.html'), '');
   }
 


### PR DESCRIPTION
When using the CLI command `component create <component name>`, and user says yes to templates, in component.json, this initializes the "templates" property to be ["template.html"] instead of the current behavior: adding "template.js" to "scripts".
