### PR TITLE
Splitting path correctly on Windows

### DIFF
--- a/bin/component
+++ b/bin/component
@@ -69,7 +69,7 @@ var local = join(__dirname, bin);
 if (exists(local)) {
   bin = local;
 } else {
-  bin = process.env.PATH.split(':').reduce(function(binary, p) {
+  bin = process.env.PATH.split(path.delimiter).reduce(function(binary, p) {
     p = resolve(p, bin);
     return exists(p) && stat(p).isFile() ? p : binary;
   }, bin);


### PR DESCRIPTION
Running `component tsc` on Windows fails with the error message `component-tsc(1) does not exist`.
This is because it splits the PATH on `:` which doesn't work well with `;` separated paths beginning `C:`

The fix to make this portable on different operating systems is to just use `path.delimiter`
